### PR TITLE
fix: condition for branch target changed to be either ref or workflow ref

### DIFF
--- a/.github/workflows/worker-delete.yml
+++ b/.github/workflows/worker-delete.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get Deleted Branch Name
         id: get_branch
         run: |
-          branch_name=$(echo '${{ github.event.ref }}' | sed 's#refs/heads/##' | sed 's#[^a-zA-Z0-9]#-#g')
+          branch_name=$(echo '${{ github.event.workflow_run.head_branch || github.ref }}' | sed 's#refs/heads/##' | sed 's#[^a-zA-Z0-9]#-#g')
           echo "branch_name=$branch_name" >> $GITHUB_ENV
       - name: Retrieve and Construct Full Worker Name
         id: construct_worker_name

--- a/.github/workflows/worker-delete.yml
+++ b/.github/workflows/worker-delete.yml
@@ -7,7 +7,7 @@ jobs:
   delete:
     runs-on: ubuntu-latest
     name: Delete Deployment
-    environment: ${{ github.ref == 'refs/heads/main' && 'main' || 'development' }}
+    environment: ${{ (github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
     steps:
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -20,11 +20,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.10.0"
-
       - uses: actions/checkout@v4
 
       - name: Setup Bun

--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -15,7 +15,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy
-    environment: ${{ github.ref == 'refs/heads/main' && 'main' || 'development' }}
+    environment: ${{ (github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main') && 'main' || 'development' }}
     permissions:
       contents: write
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Update wrangler.toml Name Field
         run: |
-          branch_name=$(echo '${{ github.ref }}' | sed 's#refs/heads/##' | sed 's#[^a-zA-Z0-9]#-#g')
+          branch_name=$(echo '${{ github.event.workflow_run.head_branch || github.ref }}' | sed 's#refs/heads/##' | sed 's#[^a-zA-Z0-9]#-#g')
           # Extract base name from wrangler.toml
           base_name=$(grep '^name = ' wrangler.toml | sed 's/^name = "\(.*\)"$/\1/')
           # Concatenate branch name with base name
@@ -101,7 +101,7 @@ jobs:
           files: |
             manifest.json
           commit-message: "chore: [skip ci] update manifest.json url"
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Write Deployment URL to Summary
         run: |

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,3 +7,6 @@ compatibility_flags = [ "nodejs_compat" ]
 
 [observability]
 enabled = true
+
+[version_metadata]
+binding = "CLOUDFLARE_VERSION_METADATA"


### PR DESCRIPTION
Resolves #124
QA:
- [development branch build](https://github.com/Meniole/command-start-stop/actions/runs/12791736846)
- [targeted branch build](https://github.com/Meniole/command-start-stop/actions/runs/12791780600)
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
