### PR TITLE
fix: handle owner-type when fetching repositories

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,123 +4,125 @@ import eslint from "@eslint/js";
 import sonarjs from "eslint-plugin-sonarjs";
 import checkFile from "eslint-plugin-check-file";
 
-export default tsEslint.config({
-  plugins: {
-    "@typescript-eslint": tsEslint.plugin,
-    "check-file": checkFile,
-  },
-  ignores: [".github/knip.ts", ".github/cspell.ts", ".wrangler/**/*.ts", ".wrangler/**/*.js", "dist/**", "eslint.config.mjs", ".husky/**"],
-  extends: [eslint.configs.recommended, ...tsEslint.configs.recommended, sonarjs.configs.recommended],
-  languageOptions: {
-    parser: tsEslint.parser,
-    parserOptions: {
-      project: ["./tsconfig.json"],
+export default tsEslint.config([
+  { ignores: [".github/knip.ts", ".github/cspell.ts", ".wrangler/**/*.ts", ".wrangler/**/*.js", "dist/**", "eslint.config.mjs", ".husky/**"] },
+  {
+    plugins: {
+      "@typescript-eslint": tsEslint.plugin,
+      "check-file": checkFile,
+    },
+    extends: [eslint.configs.recommended, ...tsEslint.configs.recommended, sonarjs.configs.recommended],
+    languageOptions: {
+      parser: tsEslint.parser,
+      parserOptions: {
+        project: ["./tsconfig.json"],
+      },
+    },
+    rules: {
+      "check-file/filename-naming-convention": [
+        "error",
+        {
+          "**/*.{js,ts}": "+([-._a-z0-9])",
+        },
+      ],
+      "prefer-arrow-callback": [
+        "warn",
+        {
+          allowNamedFunctions: true,
+        },
+      ],
+      "func-style": [
+        "warn",
+        "declaration",
+        {
+          allowArrowFunctions: false,
+        },
+      ],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "constructor-super": "error",
+      "no-invalid-this": "off",
+      "@typescript-eslint/no-invalid-this": ["error"],
+      "no-restricted-syntax": ["error", "ForInStatement"],
+      "use-isnan": "error",
+      "no-unneeded-ternary": "error",
+      "no-nested-ternary": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "after-used",
+          ignoreRestSiblings: true,
+          vars: "all",
+          varsIgnorePattern: "^_",
+          argsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/await-thenable": "error",
+      "@typescript-eslint/no-misused-new": "error",
+      "@typescript-eslint/restrict-plus-operands": "error",
+      "sonarjs/no-all-duplicated-branches": "error",
+      "sonarjs/no-collection-size-mischeck": "error",
+      "sonarjs/no-duplicated-branches": "error",
+      "sonarjs/no-element-overwrite": "error",
+      "sonarjs/no-identical-conditions": "error",
+      "sonarjs/no-identical-expressions": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          selector: "interface",
+          format: ["StrictPascalCase"],
+          custom: {
+            regex: "^I[A-Z]",
+            match: false,
+          },
+        },
+        {
+          selector: "memberLike",
+          modifiers: ["private"],
+          format: ["strictCamelCase"],
+          leadingUnderscore: "require",
+        },
+        {
+          selector: "typeLike",
+          format: ["StrictPascalCase"],
+        },
+        {
+          selector: "typeParameter",
+          format: ["StrictPascalCase"],
+          prefix: ["T"],
+        },
+        {
+          selector: "variable",
+          format: ["strictCamelCase", "UPPER_CASE"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allow",
+        },
+        {
+          selector: "variable",
+          format: ["strictCamelCase"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allow",
+        },
+        {
+          selector: "variable",
+          modifiers: ["destructured"],
+          format: null,
+        },
+        {
+          selector: "variable",
+          types: ["boolean"],
+          format: ["StrictPascalCase"],
+          prefix: ["is", "should", "has", "can", "did", "will", "does"],
+        },
+        {
+          selector: "variableLike",
+          format: ["strictCamelCase"],
+        },
+        {
+          selector: ["function", "variable"],
+          format: ["strictCamelCase"],
+        },
+      ],
     },
   },
-  rules: {
-    "check-file/filename-naming-convention": [
-      "error",
-      {
-        "**/*.{js,ts}": "+([-._a-z0-9])",
-      },
-    ],
-    "prefer-arrow-callback": [
-      "warn",
-      {
-        allowNamedFunctions: true,
-      },
-    ],
-    "func-style": [
-      "warn",
-      "declaration",
-      {
-        allowArrowFunctions: false,
-      },
-    ],
-    "@typescript-eslint/no-floating-promises": "error",
-    "@typescript-eslint/no-non-null-assertion": "error",
-    "constructor-super": "error",
-    "no-invalid-this": "off",
-    "@typescript-eslint/no-invalid-this": ["error"],
-    "no-restricted-syntax": ["error", "ForInStatement"],
-    "use-isnan": "error",
-    "no-unneeded-ternary": "error",
-    "no-nested-ternary": "error",
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        args: "after-used",
-        ignoreRestSiblings: true,
-        vars: "all",
-        varsIgnorePattern: "^_",
-        argsIgnorePattern: "^_",
-      },
-    ],
-    "@typescript-eslint/await-thenable": "error",
-    "@typescript-eslint/no-misused-new": "error",
-    "@typescript-eslint/restrict-plus-operands": "error",
-    "sonarjs/no-all-duplicated-branches": "error",
-    "sonarjs/no-collection-size-mischeck": "error",
-    "sonarjs/no-duplicated-branches": "error",
-    "sonarjs/no-element-overwrite": "error",
-    "sonarjs/no-identical-conditions": "error",
-    "sonarjs/no-identical-expressions": "error",
-    "@typescript-eslint/naming-convention": [
-      "error",
-      {
-        selector: "interface",
-        format: ["StrictPascalCase"],
-        custom: {
-          regex: "^I[A-Z]",
-          match: false,
-        },
-      },
-      {
-        selector: "memberLike",
-        modifiers: ["private"],
-        format: ["strictCamelCase"],
-        leadingUnderscore: "require",
-      },
-      {
-        selector: "typeLike",
-        format: ["StrictPascalCase"],
-      },
-      {
-        selector: "typeParameter",
-        format: ["StrictPascalCase"],
-        prefix: ["T"],
-      },
-      {
-        selector: "variable",
-        format: ["strictCamelCase", "UPPER_CASE"],
-        leadingUnderscore: "allow",
-        trailingUnderscore: "allow",
-      },
-      {
-        selector: "variable",
-        format: ["strictCamelCase"],
-        leadingUnderscore: "allow",
-        trailingUnderscore: "allow",
-      },
-      {
-        selector: "variable",
-        modifiers: ["destructured"],
-        format: null,
-      },
-      {
-        selector: "variable",
-        types: ["boolean"],
-        format: ["StrictPascalCase"],
-        prefix: ["is", "should", "has", "can", "did", "will", "does"],
-      },
-      {
-        selector: "variableLike",
-        format: ["strictCamelCase"],
-      },
-      {
-        selector: ["function", "variable"],
-        format: ["strictCamelCase"],
-      },
-    ],
-  },
-});
+]);

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,7 @@
 {
   "name": "Start | Stop",
   "description": "Assign or un-assign yourself from an issue/task.",
-  "ubiquity:listeners": [
-    "issues.unassigned",
-    "pull_request.opened",
-    "pull_request.edited"
-  ],
+  "ubiquity:listeners": ["issues.unassigned", "pull_request.opened", "pull_request.edited"],
   "commands": {
     "start": {
       "ubiquity:example": "/start",
@@ -39,19 +35,13 @@
     "properties": {
       "reviewDelayTolerance": {
         "default": "1 Day",
-        "examples": [
-          "1 Day",
-          "5 Days"
-        ],
+        "examples": ["1 Day", "5 Days"],
         "description": "When considering a user for a task: if they have existing PRs with no reviews, how long should we wait before 'increasing' their assignable task limit?",
         "type": "string"
       },
       "taskStaleTimeoutDuration": {
         "default": "30 Days",
-        "examples": [
-          "1 Day",
-          "5 Days"
-        ],
+        "examples": ["1 Day", "5 Days"],
         "description": "When displaying the '/start' response, how long should we wait before considering a task 'stale' and provide a warning?",
         "type": "string"
       },
@@ -84,11 +74,7 @@
       "assignedIssueScope": {
         "default": "org",
         "description": "When considering a user for a task: should we consider their assigned issues at the org, repo, or network level?",
-        "examples": [
-          "org",
-          "repo",
-          "network"
-        ],
+        "examples": ["org", "repo", "network"],
         "anyOf": [
           {
             "const": "org",
@@ -110,23 +96,12 @@
         "type": "string"
       },
       "rolesWithReviewAuthority": {
-        "default": [
-          "OWNER",
-          "ADMIN",
-          "MEMBER",
-          "COLLABORATOR"
-        ],
+        "default": ["OWNER", "ADMIN", "MEMBER", "COLLABORATOR"],
         "uniqueItems": true,
         "description": "When considering a user for a task: which roles should be considered as having review authority? All others are ignored.",
         "examples": [
-          [
-            "OWNER",
-            "ADMIN"
-          ],
-          [
-            "MEMBER",
-            "COLLABORATOR"
-          ]
+          ["OWNER", "ADMIN"],
+          ["MEMBER", "COLLABORATOR"]
         ],
         "type": "array",
         "items": {
@@ -153,14 +128,7 @@
       "requiredLabelsToStart": {
         "default": [],
         "description": "If set, a task must have at least one of these labels to be started.",
-        "examples": [
-          [
-            "Priority: 5 (Emergency)"
-          ],
-          [
-            "Good First Issue"
-          ]
-        ],
+        "examples": [["Priority: 5 (Emergency)"], ["Good First Issue"]],
         "type": "array",
         "items": {
           "type": "object",
@@ -173,12 +141,7 @@
               "description": "The list of allowed roles to start the task with the given label.",
               "uniqueItems": true,
               "default": [],
-              "examples": [
-                [
-                  "collaborator",
-                  "contributor"
-                ]
-              ],
+              "examples": [["collaborator", "contributor"]],
               "type": "array",
               "items": {
                 "anyOf": [
@@ -194,9 +157,7 @@
               }
             }
           },
-          "required": [
-            "name"
-          ]
+          "required": ["name"]
         }
       },
       "taskAccessControl": {

--- a/tests/fallbacks.test.ts
+++ b/tests/fallbacks.test.ts
@@ -20,6 +20,9 @@ const mockOctokit = {
     repos: {
       listForOrg: jest.fn(() => mockPullRequestData),
     },
+    users: {
+      getByUsername: jest.fn(() => ({ data: { login: username } })),
+    },
   },
 };
 


### PR DESCRIPTION
Resolves #172
[QA Org](https://github.com/Meniole/command-start-stop/issues/72)
[QA non-org](https://github.com/gentlementlegen/command-start-stop/issues/12)

Maybe there is an edge case that I couldn't test, will conduct tests with the `demo` after merging.
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
