### PR TITLE
fix: account for reviewer-lagged review threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To start a task, a hunter should use the `/start` command. This will assign them
 - Price labels are set on the issue
 - The issue is not already assigned
 - The hunter has not reached the maximum number of concurrent tasks
+  - Open pull requests waiting on reviewers can stop counting against this limit after `reviewDelayTolerance`, including when the hunter is the last commenter on every unresolved review thread.
 - The command is not disabled at the repository or organization level
 - The contributor's GitHub account meets the minimum age requirement (default: 365.25 days)
 - The contributor has sufficient XP for the task's priority level (if configured)
@@ -217,7 +218,7 @@ To configure your Ubiquity Kernel to run this plugin, add the following to the `
 - plugin: http://localhost:4000 # or the URL where the plugin is hosted
   id: start-stop-command
   with:
-    reviewDelayTolerance: "3 Days"
+    reviewDelayTolerance: "3 Days" # Delay before reviewer-lagged pull requests stop counting against task limits.
     taskStaleTimeoutDuration: "30 Days"
     maxConcurrentTasks: # Default concurrent task limits per role.
       collaborator: 5

--- a/src/github-queries.ts
+++ b/src/github-queries.ts
@@ -25,3 +25,29 @@ export const QUERY_OPEN_LINKED_PULL_REQUESTS_FOR_ISSUE = /* GraphQL */ `
     }
   }
 `;
+
+export const QUERY_PULL_REQUEST_REVIEW_THREADS = /* GraphQL */ `
+  query pullRequestReviewThreads($owner: String!, $repo: String!, $pull_number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pull_number) {
+        reviewThreads(first: 100, after: $cursor) {
+          nodes {
+            isResolved
+            comments(last: 1) {
+              nodes {
+                createdAt
+                author {
+                  login
+                }
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -127,7 +127,7 @@ export const pluginSettingsSchema = T.Object(
       default: "1 Day",
       examples: ["1 Day", "5 Days"],
       description:
-        "When considering a user for a task: if they have existing PRs with no reviews, how long should we wait before 'increasing' their assignable task limit?",
+        "When considering a user for a task: how long should we wait before increasing their assignable task limit when existing PRs are waiting on reviewers, including PRs where the user is the last commenter on every unresolved review thread?",
     }),
     taskStaleTimeoutDuration: T.String({
       default: "30 Days",

--- a/src/utils/issue.ts
+++ b/src/utils/issue.ts
@@ -1,5 +1,6 @@
 import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 import ms from "ms";
+import { QUERY_PULL_REQUEST_REVIEW_THREADS } from "../github-queries";
 import { Context } from "../types/context";
 import { AssignedIssue, GitHubIssueSearch, PrState, Review } from "../types/payload";
 import { AssignedIssueScope, Role } from "../types/plugin-input";
@@ -240,11 +241,72 @@ async function getReviewByUser(context: Context, pullRequest: Awaited<ReturnType
   return latestReviewsByUser;
 }
 
+type ReviewThreadComment = {
+  createdAt?: string | null;
+  author?: {
+    login?: string | null;
+  } | null;
+};
+
+type ReviewThread = {
+  isResolved?: boolean | null;
+  comments?: {
+    nodes?: (ReviewThreadComment | null)[] | null;
+  } | null;
+};
+
+type PullRequestReviewThreadsResponse = {
+  repository?: {
+    pullRequest?: {
+      reviewThreads?: {
+        nodes?: (ReviewThread | null)[] | null;
+      } | null;
+    } | null;
+  } | null;
+};
+
+async function getUnresolvedReviewThreads(context: Context, owner: string, repo: string, pullNumber: number): Promise<ReviewThread[]> {
+  const response = await context.octokit.graphql.paginate<PullRequestReviewThreadsResponse>(QUERY_PULL_REQUEST_REVIEW_THREADS, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+
+  return (response.repository?.pullRequest?.reviewThreads?.nodes ?? []).filter((thread): thread is ReviewThread => !!thread && !thread.isResolved);
+}
+
+function getLastThreadComment(thread: ReviewThread) {
+  return thread.comments?.nodes?.filter((comment): comment is ReviewThreadComment => !!comment).at(-1);
+}
+
+async function areReviewThreadsWaitingOnReviewers(
+  context: Context,
+  pullRequest: Awaited<ReturnType<typeof getOpenedPullRequestsForUser>>[0],
+  username: string,
+  { owner, repo }: { owner: string; repo: string },
+  reviewDelayTolerance: string
+) {
+  const unresolvedThreads = await getUnresolvedReviewThreads(context, owner, repo, pullRequest.number);
+  if (!unresolvedThreads.length) {
+    return false;
+  }
+
+  const delay = getTimeValue(reviewDelayTolerance);
+
+  return unresolvedThreads.every((thread) => {
+    const lastComment = getLastThreadComment(thread);
+    if (!lastComment?.createdAt || lastComment.author?.login?.toLowerCase() !== username.toLowerCase()) {
+      return false;
+    }
+    return new Date().getTime() - new Date(lastComment.createdAt).getTime() >= delay;
+  });
+}
+
 async function shouldSkipPullRequest(
   context: Context,
   pullRequest: Awaited<ReturnType<typeof getOpenedPullRequestsForUser>>[0],
   reviews: Awaited<ReturnType<typeof getReviewByUser>>,
-  { owner, repo, issueNumber }: { owner: string; repo: string; issueNumber: number },
+  { owner, repo, issueNumber, username }: { owner: string; repo: string; issueNumber: number; username: string },
   reviewDelayTolerance: string
 ) {
   const timeline = await context.octokit.paginate(context.octokit.rest.issues.listEventsForTimeline, {
@@ -260,9 +322,10 @@ async function shouldSkipPullRequest(
     return new Date().getTime() - referenceTime >= getTimeValue(reviewDelayTolerance);
   }
 
-  // If changes are requested, do not skip
+  // If changes are requested, only stop counting the PR against the author when they
+  // replied last on every unresolved review thread and reviewers have had enough time to respond.
   if (Array.from(reviews.values()).some((review) => review.state === "CHANGES_REQUESTED")) {
-    return true;
+    return areReviewThreadsWaitingOnReviewers(context, pullRequest, username, { owner, repo }, reviewDelayTolerance);
   }
 
   // If no approvals exist or time reference has exceeded review delay tolerance
@@ -291,7 +354,7 @@ export async function getPendingOpenedPullRequests(context: Context, username: s
       context,
       openedPullRequest,
       latestReviewsByUser,
-      { owner, repo, issueNumber: openedPullRequest.number },
+      { owner, repo, issueNumber: openedPullRequest.number, username },
       reviewDelayTolerance
     );
     if (!shouldSkipPr) {

--- a/tests/review-thread-lag.test.ts
+++ b/tests/review-thread-lag.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { Context } from "../src/types/context";
+import { AssignedIssueScope, Role } from "../src/types/plugin-input";
+import { getPendingOpenedPullRequests } from "../src/utils/issue";
+
+const username = "contributor";
+
+function createContext({ lastCommentAuthor, lastCommentAt }: { lastCommentAuthor: string; lastCommentAt: string }) {
+  const issuesAndPullRequests = jest.fn();
+  const listReviews = jest.fn();
+  const listEventsForTimeline = jest.fn();
+
+  const pullRequest = {
+    number: 123,
+    html_url: "https://github.com/ubiquity/test/pull/123",
+    created_at: "2026-05-01T00:00:00Z",
+    requested_reviewers: [],
+  };
+
+  const review = {
+    id: 1,
+    state: "CHANGES_REQUESTED",
+    submitted_at: "2026-05-10T00:00:00Z",
+    author_association: Role.MEMBER,
+    user: {
+      id: 10,
+      login: "reviewer",
+    },
+  };
+
+  const paginate = jest.fn((endpoint: unknown) => {
+    if (endpoint === issuesAndPullRequests) {
+      return [pullRequest];
+    }
+    if (endpoint === listReviews) {
+      return [review];
+    }
+    if (endpoint === listEventsForTimeline) {
+      return [{ event: "review_requested", created_at: "2026-05-09T00:00:00Z" }];
+    }
+    return [];
+  });
+
+  return {
+    logger: new Logs("debug"),
+    organizations: ["ubiquity"],
+    config: {
+      assignedIssueScope: AssignedIssueScope.ORG,
+      rolesWithReviewAuthority: [Role.ADMIN, Role.OWNER, Role.MEMBER],
+      reviewDelayTolerance: "1 Day",
+    },
+    payload: {
+      repository: {
+        full_name: "ubiquity/test",
+        name: "test",
+        owner: {
+          login: "ubiquity",
+        },
+      },
+    },
+    octokit: {
+      paginate,
+      graphql: {
+        paginate: jest.fn(() => ({
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [
+                  {
+                    isResolved: false,
+                    comments: {
+                      nodes: [
+                        {
+                          createdAt: lastCommentAt,
+                          author: {
+                            login: lastCommentAuthor,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })),
+      },
+      rest: {
+        search: {
+          issuesAndPullRequests,
+        },
+        pulls: {
+          listReviews,
+        },
+        issues: {
+          listEventsForTimeline,
+        },
+      },
+    },
+  } as unknown as Context;
+}
+
+describe("review-thread task-limit bypass", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-05-12T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not count a pull request against the task limit when the contributor replied last on every unresolved thread and the delay passed", async () => {
+    const context = createContext({ lastCommentAuthor: username, lastCommentAt: "2026-05-10T23:00:00Z" });
+
+    await expect(getPendingOpenedPullRequests(context, username)).resolves.toEqual([]);
+  });
+
+  it("counts a pull request against the task limit when a reviewer is the last commenter on an unresolved thread", async () => {
+    const context = createContext({ lastCommentAuthor: "reviewer", lastCommentAt: "2026-05-10T23:00:00Z" });
+
+    await expect(getPendingOpenedPullRequests(context, username)).resolves.toHaveLength(1);
+  });
+
+  it("counts a pull request against the task limit when the contributor reply is still within the delay window", async () => {
+    const context = createContext({ lastCommentAuthor: username, lastCommentAt: "2026-05-11T12:00:00Z" });
+
+    await expect(getPendingOpenedPullRequests(context, username)).resolves.toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Updates task limit handling so a pull request with requested changes can stop counting against the contributor's task limit when the contributor is waiting on reviewers: they must be the latest commenter on every unresolved review thread, and the configured `reviewDelayTolerance` must have elapsed since those replies.

## Changes

- Adds a GraphQL review-thread query for unresolved pull request review threads.
- Checks unresolved review threads before bypassing task limits for `CHANGES_REQUESTED` reviews.
- Keeps PRs counted when a reviewer replied last, when contributor replies are still inside the delay window, or when there are no unresolved review threads to verify.
- Documents the reviewer-lag behavior and adds focused Jest coverage.

## Testing

- `bun run test:jest tests/review-thread-lag.test.ts --runInBand --silent`
- `bun x tsc --noEmit`
- `bun run format:lint --max-warnings=0`
- Also ran the full Jest suite; it still has the same 5 failures in `tests/pull-request.test.ts` on the unmodified base branch, so these appear pre-existing in this environment rather than introduced by this change.

Fixes ubiquity-os-marketplace/command-start-stop#106
