### PR TITLE
fix: handle reviewer-lagged task limits

### DIFF
--- a/src/utils/issue.ts
+++ b/src/utils/issue.ts
@@ -6,6 +6,13 @@ import { AssignedIssueScope, Role } from "../types/plugin-input";
 import { getOpenLinkedPullRequestsForIssue, GetLinkedResults } from "./get-linked-prs";
 import { getAllPullRequestsFallback, getAssignedIssuesFallback } from "./get-pull-requests-fallback";
 
+const REVIEWER_LAG_TIMEOUT = "24 Hours";
+
+type ReviewThreadLastComment = {
+  authorLogin: string | null;
+  createdAt: string | null;
+};
+
 export function isParentIssue(body: string) {
   const parentPattern = /-\s+\[( |x)\]\s+#\d+/;
   return body.match(parentPattern);
@@ -240,8 +247,99 @@ async function getReviewByUser(context: Context, pullRequest: Awaited<ReturnType
   return latestReviewsByUser;
 }
 
+async function getUnresolvedReviewThreadLastComments(
+  context: Context,
+  pullRequest: Awaited<ReturnType<typeof getOpenedPullRequestsForUser>>[0],
+  owner: string,
+  repo: string
+): Promise<ReviewThreadLastComment[]> {
+  if (!("graphql" in context.octokit) || typeof context.octokit.graphql !== "function") {
+    return [];
+  }
+
+  try {
+    const response = (await context.octokit.graphql(
+      `
+        query PullRequestReviewThreads($owner: String!, $repo: String!, $pullNumber: Int!) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pullNumber) {
+              reviewThreads(first: 100) {
+                nodes {
+                  isResolved
+                  comments(last: 1) {
+                    nodes {
+                      author {
+                        login
+                      }
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      {
+        owner,
+        repo,
+        pullNumber: pullRequest.number,
+      }
+    )) as {
+      repository?: {
+        pullRequest?: {
+          reviewThreads?: {
+            nodes?: {
+              isResolved?: boolean;
+              comments?: {
+                nodes?: {
+                  author?: {
+                    login?: string;
+                  } | null;
+                  createdAt?: string;
+                }[];
+              };
+            }[];
+          };
+        };
+      };
+    };
+
+    return (
+      response.repository?.pullRequest?.reviewThreads?.nodes
+        ?.filter((thread) => !thread.isResolved)
+        .map((thread) => {
+          const lastComment = thread.comments?.nodes?.at(-1);
+          return {
+            authorLogin: lastComment?.author?.login ?? null,
+            createdAt: lastComment?.createdAt ?? null,
+          };
+        }) ?? []
+    );
+  } catch (err) {
+    context.logger.debug("Fetching pull request review threads failed", { error: err as Error, owner, repo, pullRequest: pullRequest.number });
+    return [];
+  }
+}
+
+function isReviewerLagged(username: string, unresolvedThreads: ReviewThreadLastComment[]) {
+  if (!unresolvedThreads.length) {
+    return false;
+  }
+
+  const timeout = getTimeValue(REVIEWER_LAG_TIMEOUT);
+  return unresolvedThreads.every((thread) => {
+    if (!thread.authorLogin || !thread.createdAt || thread.authorLogin.toLowerCase() !== username.toLowerCase()) {
+      return false;
+    }
+
+    return new Date().getTime() - new Date(thread.createdAt).getTime() >= timeout;
+  });
+}
+
 async function shouldSkipPullRequest(
   context: Context,
+  username: string,
   pullRequest: Awaited<ReturnType<typeof getOpenedPullRequestsForUser>>[0],
   reviews: Awaited<ReturnType<typeof getReviewByUser>>,
   { owner, repo, issueNumber }: { owner: string; repo: string; issueNumber: number },
@@ -262,7 +360,8 @@ async function shouldSkipPullRequest(
 
   // If changes are requested, do not skip
   if (Array.from(reviews.values()).some((review) => review.state === "CHANGES_REQUESTED")) {
-    return true;
+    const unresolvedThreads = await getUnresolvedReviewThreadLastComments(context, pullRequest, owner, repo);
+    return isReviewerLagged(username, unresolvedThreads);
   }
 
   // If no approvals exist or time reference has exceeded review delay tolerance
@@ -289,6 +388,7 @@ export async function getPendingOpenedPullRequests(context: Context, username: s
     const latestReviewsByUser = await getReviewByUser(context, openedPullRequest);
     const shouldSkipPr = await shouldSkipPullRequest(
       context,
+      username,
       openedPullRequest,
       latestReviewsByUser,
       { owner, repo, issueNumber: openedPullRequest.number },

--- a/tests/issue.test.ts
+++ b/tests/issue.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { Context } from "../src/types/context";
+import { AssignedIssueScope, Role } from "../src/types/plugin-input";
+import { getPendingOpenedPullRequests } from "../src/utils/issue";
+
+const username = "contributor";
+const reviewer = "reviewer";
+const owner = "ubiquity";
+const repo = "test-repo";
+
+const pullRequest = {
+  id: 1,
+  number: 10,
+  html_url: `https://github.com/${owner}/${repo}/pull/10`,
+  created_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+  requested_reviewers: [],
+  user: {
+    id: 1,
+    login: username,
+  },
+};
+
+const changesRequestedReview = {
+  id: 1,
+  state: "CHANGES_REQUESTED",
+  submitted_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+  user: {
+    id: 2,
+    login: reviewer,
+  },
+  author_association: Role.MEMBER,
+};
+
+function createContext(reviewThreads: unknown[] | null): Context {
+  const rest = {
+    search: {
+      issuesAndPullRequests: jest.fn(),
+    },
+    pulls: {
+      listReviews: jest.fn(),
+    },
+    issues: {
+      listEventsForTimeline: jest.fn(),
+    },
+  };
+
+  const octokit = {
+    rest,
+    paginate: jest.fn((endpoint) => {
+      if (endpoint === rest.search.issuesAndPullRequests) {
+        return [pullRequest];
+      }
+
+      if (endpoint === rest.pulls.listReviews) {
+        return [changesRequestedReview];
+      }
+
+      if (endpoint === rest.issues.listEventsForTimeline) {
+        return [];
+      }
+
+      return [];
+    }),
+    graphql:
+      reviewThreads === null
+        ? undefined
+        : jest.fn(() => ({
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: reviewThreads,
+                },
+              },
+            },
+          })),
+  };
+
+  return {
+    eventName: "issue_comment.created",
+    payload: {
+      repository: {
+        full_name: `${owner}/${repo}`,
+        name: repo,
+        owner: {
+          login: owner,
+        },
+      },
+    },
+    organizations: [owner],
+    config: {
+      assignedIssueScope: AssignedIssueScope.REPO,
+      reviewDelayTolerance: "3 Days",
+      rolesWithReviewAuthority: [Role.MEMBER],
+    },
+    octokit,
+    logger: new Logs("debug"),
+  } as unknown as Context;
+}
+
+function unresolvedThread(authorLogin: string, createdAt: string) {
+  return {
+    isResolved: false,
+    comments: {
+      nodes: [
+        {
+          author: {
+            login: authorLogin,
+          },
+          createdAt,
+        },
+      ],
+    },
+  };
+}
+
+describe("getPendingOpenedPullRequests", () => {
+  it("does not count a PR against the task limit when the assignee answered all unresolved review threads over 24 hours ago", async () => {
+    const context = createContext([unresolvedThread(username, new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString())]);
+
+    await expect(getPendingOpenedPullRequests(context, username)).resolves.toHaveLength(0);
+  });
+
+  it("continues to count a PR against the task limit when a reviewer has the last unresolved review-thread comment", async () => {
+    const context = createContext([unresolvedThread(reviewer, new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString())]);
+
+    await expect(getPendingOpenedPullRequests(context, username)).resolves.toEqual([pullRequest]);
+  });
+
+  it("continues to count a PR against the task limit when review-thread data is unavailable", async () => {
+    const context = createContext(null);
+
+    await expect(getPendingOpenedPullRequests(context, username)).resolves.toEqual([pullRequest]);
+  });
+});


### PR DESCRIPTION
## Summary

- add review-thread awareness to task-limit bypass logic for `CHANGES_REQUESTED` pull requests
- only treat a PR as reviewer-lagged when every unresolved review thread was last answered by the assignee and that last answer is at least 24 hours old
- add focused tests for assignee-last-comment, reviewer-last-comment, and unavailable review-thread data

## Verification

```bash
bunx tsc --noEmit
bunx jest tests/issue.test.ts --runInBand
bunx prettier --check src/utils/issue.ts tests/issue.test.ts
bunx eslint src/utils/issue.ts tests/issue.test.ts
```

Targeted verification passes.

Full suite note:

```bash
bun run test:jest --runInBand
```

The full suite currently reports 5 failures in `tests/pull-request.test.ts` around expected pull-request comment mocks not being called. The new `tests/issue.test.ts` file passes, and the failures are outside the task-limit review-thread path changed in this PR.

Closes #106
