### PR TITLE
feat: bypass task limit when all pending PRs are reviewer-lagged

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,9 +3,10 @@ import type { Config } from "jest";
 const cfg: Config = {
   testEnvironment: "node",
   transform: {
-    "^.+\\.[jt]s$": "@swc/jest",
+    "^.+\\.[jt]sx?$": "@swc/jest",
+    "^.+\\.mjs$": "@swc/jest",
   },
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "mjs", "json", "node"],
   coveragePathIgnorePatterns: ["node_modules", "mocks", "tests"],
   collectCoverage: true,
   coverageReporters: ["json", "lcov", "text", "clover", "json-summary"],

--- a/src/github-queries.ts
+++ b/src/github-queries.ts
@@ -1,3 +1,25 @@
+export const QUERY_PULL_REQUEST_REVIEW_THREADS = /* GraphQL */ `
+  query pullRequestReviewThreads($owner: String!, $repo: String!, $prNumber: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $prNumber) {
+        reviewThreads(first: 100) {
+          nodes {
+            isResolved
+            comments(last: 1) {
+              nodes {
+                author {
+                  login
+                }
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const QUERY_OPEN_LINKED_PULL_REQUESTS_FOR_ISSUE = /* GraphQL */ `
   query openLinkedPullRequestsForIssue($owner: String!, $repo: String!, $issue_number: Int!, $cursor: String) {
     repository(owner: $owner, name: $repo) {

--- a/src/handlers/start/helpers/check-assignments.ts
+++ b/src/handlers/start/helpers/check-assignments.ts
@@ -1,8 +1,29 @@
+import { QUERY_PULL_REQUEST_REVIEW_THREADS } from "../../../github-queries";
 import { Context } from "../../../types/context";
 import { getAssignmentPeriods } from "../../../utils/get-assignment-periods";
 import { getUserRoleAndTaskLimit } from "../../../utils/get-user-task-limit-and-role";
-import { getAssignedIssues, getOwnerRepoFromHtmlUrl, getPendingOpenedPullRequests } from "../../../utils/issue";
+import { getAssignedIssues, getOwnerRepoFromHtmlUrl, getPendingOpenedPullRequests, getTimeValue } from "../../../utils/issue";
 import { ERROR_MESSAGES } from "./error-messages";
+
+interface ReviewThreadComment {
+  author: { login: string } | null;
+  updatedAt: string;
+}
+
+interface ReviewThreadNode {
+  isResolved: boolean;
+  comments: { nodes: ReviewThreadComment[] };
+}
+
+interface PullRequestReviewThreadsResult {
+  repository: {
+    pullRequest: {
+      reviewThreads: {
+        nodes: ReviewThreadNode[];
+      };
+    } | null;
+  } | null;
+}
 
 async function hasUserBeenUnassigned(context: Context, username: string): Promise<boolean> {
   if ("issue" in context.payload) {
@@ -13,6 +34,58 @@ async function hasUserBeenUnassigned(context: Context, username: string): Promis
   }
 
   return false;
+}
+
+async function isPrReviewerLagged(
+  context: Context,
+  username: string,
+  prOwner: string,
+  prRepo: string,
+  prNumber: number,
+  toleranceMs: number
+): Promise<boolean> {
+  try {
+    const result = await context.octokit.graphql<PullRequestReviewThreadsResult>(QUERY_PULL_REQUEST_REVIEW_THREADS, {
+      owner: prOwner,
+      repo: prRepo,
+      prNumber,
+    });
+
+    const threads = result?.repository?.pullRequest?.reviewThreads?.nodes;
+    if (!threads?.length) return false;
+
+    const unresolvedThreads = threads.filter((t) => !t.isResolved);
+    if (!unresolvedThreads.length) return false;
+
+    const now = Date.now();
+    return unresolvedThreads.every((thread) => {
+      const lastComment = thread.comments.nodes[thread.comments.nodes.length - 1];
+      if (!lastComment) return false;
+      if (lastComment.author?.login?.toLowerCase() !== username.toLowerCase()) return false;
+      return now - new Date(lastComment.updatedAt).getTime() >= toleranceMs;
+    });
+  } catch {
+    return false;
+  }
+}
+
+export async function isUserReviewerLagged(
+  context: Context,
+  username: string,
+  pendingPullRequests: Array<{ html_url: string; number: number }>,
+  reviewDelayTolerance: string
+): Promise<boolean> {
+  if (!pendingPullRequests.length) return false;
+
+  const toleranceMs = getTimeValue(reviewDelayTolerance);
+
+  for (const pr of pendingPullRequests) {
+    const { owner, repo } = getOwnerRepoFromHtmlUrl(pr.html_url);
+    const isLagged = await isPrReviewerLagged(context, username, owner, repo, pr.number, toleranceMs);
+    if (!isLagged) return false;
+  }
+
+  return true;
 }
 
 export async function handleTaskLimitChecks({
@@ -44,11 +117,24 @@ export async function handleTaskLimitChecks({
       assignedIssues,
       openedPullRequests,
       role,
+      isReviewerLagged: false,
     };
   }
 
   // check for max and enforce max
   if (!isWithinLimit) {
+    const isLagged = await isUserReviewerLagged(context, username, openedPullRequests, context.config.reviewDelayTolerance);
+    if (isLagged) {
+      logger.info("User's pending PRs are all reviewer-lagged, bypassing task limit.", { username });
+      return {
+        isUnassigned: false,
+        isWithinLimit: true,
+        assignedIssues,
+        openedPullRequests,
+        role,
+        isReviewerLagged: true,
+      };
+    }
     const errorMessage = username === sender ? ERROR_MESSAGES.MAX_TASK_LIMIT_PREFIX : `${username} ${ERROR_MESSAGES.MAX_TASK_LIMIT_TEAMMATE_PREFIX}`;
     logger.warn(errorMessage, {
       assignedIssues: assignedIssues.length,
@@ -63,5 +149,6 @@ export async function handleTaskLimitChecks({
     assignedIssues,
     openedPullRequests,
     role,
+    isReviewerLagged: false,
   };
 }

--- a/tests/__mocks__/handlers.ts
+++ b/tests/__mocks__/handlers.ts
@@ -316,6 +316,20 @@ export const handlers = [
     const query = body.query ?? "";
     const variables = body.variables ?? {};
 
+    if (query.includes("pullRequestReviewThreads")) {
+      return HttpResponse.json({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [],
+              },
+            },
+          },
+        },
+      });
+    }
+
     if (query.includes("closedByPullRequestsReferences")) {
       const issueNumber = Number(variables.issue_number);
       const owner = String(variables.owner ?? "");

--- a/tests/reviewer-lag.test.ts
+++ b/tests/reviewer-lag.test.ts
@@ -1,0 +1,222 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { drop } from "@mswjs/data";
+import dotenv from "dotenv";
+import { isUserReviewerLagged } from "../src/handlers/start/helpers/check-assignments";
+import { Context } from "../src/types/context";
+import { db } from "./__mocks__/db";
+import issueTemplate from "./__mocks__/issue-template";
+import { server } from "./__mocks__/node";
+import { createContext } from "./utils";
+
+dotenv.config();
+
+type Issue = Context<"issue_comment.created">["payload"]["issue"];
+type PayloadSender = Context["payload"]["sender"];
+
+const checkAssignmentsPath = "../src/handlers/start/helpers/check-assignments";
+const issueUtilsPath = "../src/utils/issue";
+const userLimitUtilsPath = "../src/utils/get-user-task-limit-and-role";
+const assignmentPeriodsPath = "../src/utils/get-assignment-periods";
+
+const REVIEW_DELAY_TOLERANCE = "3 Days";
+const PR_ONE_URL = "https://github.com/owner/repo/pull/1";
+const PR_ONE = { html_url: PR_ONE_URL, number: 1 };
+// 5 days in the past — beyond any tolerance
+const OLD_DATE = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+// 1 minute in the past — within any reasonable tolerance
+const RECENT_DATE = new Date(Date.now() - 60 * 1000).toISOString();
+
+function buildThreadsResult(threads: Array<{ isResolved: boolean; authorLogin: string; updatedAt: string }>) {
+  return {
+    repository: {
+      pullRequest: {
+        reviewThreads: {
+          nodes: threads.map((t) => ({
+            isResolved: t.isResolved,
+            comments: {
+              nodes: [{ author: { login: t.authorLogin }, updatedAt: t.updatedAt }],
+            },
+          })),
+        },
+      },
+    },
+  };
+}
+
+function makeMinimalContext(graphqlFn: jest.Mock): Context {
+  return {
+    octokit: { graphql: graphqlFn },
+    config: { reviewDelayTolerance: REVIEW_DELAY_TOLERANCE },
+    logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn(), ok: jest.fn() },
+  } as unknown as Context;
+}
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  jest.restoreAllMocks();
+});
+afterAll(() => server.close());
+
+describe("isUserReviewerLagged", () => {
+  it("returns false when there are no pending PRs", async () => {
+    const graphqlFn = jest.fn() as jest.Mock;
+    const ctx = makeMinimalContext(graphqlFn);
+    expect(await isUserReviewerLagged(ctx, "alice", [], REVIEW_DELAY_TOLERANCE)).toBe(false);
+    expect(graphqlFn).not.toHaveBeenCalled();
+  });
+
+  it("returns false when a PR has only resolved threads", async () => {
+    const graphqlFn = jest.fn().mockResolvedValue(buildThreadsResult([{ isResolved: true, authorLogin: "alice", updatedAt: OLD_DATE }])) as jest.Mock;
+    const ctx = makeMinimalContext(graphqlFn);
+    expect(await isUserReviewerLagged(ctx, "alice", [PR_ONE], REVIEW_DELAY_TOLERANCE)).toBe(false);
+  });
+
+  it("returns false when the reviewer — not the user — last commented on an unresolved thread", async () => {
+    const graphqlFn = jest.fn().mockResolvedValue(buildThreadsResult([{ isResolved: false, authorLogin: "reviewer", updatedAt: OLD_DATE }])) as jest.Mock;
+    const ctx = makeMinimalContext(graphqlFn);
+    expect(await isUserReviewerLagged(ctx, "alice", [PR_ONE], REVIEW_DELAY_TOLERANCE)).toBe(false);
+  });
+
+  it("returns false when user last commented but within the tolerance window", async () => {
+    const graphqlFn = jest.fn().mockResolvedValue(buildThreadsResult([{ isResolved: false, authorLogin: "alice", updatedAt: RECENT_DATE }])) as jest.Mock;
+    const ctx = makeMinimalContext(graphqlFn);
+    expect(await isUserReviewerLagged(ctx, "alice", [PR_ONE], REVIEW_DELAY_TOLERANCE)).toBe(false);
+  });
+
+  it("returns true when user is last commenter on all unresolved threads and beyond the tolerance", async () => {
+    const graphqlFn = jest.fn().mockResolvedValue(
+      buildThreadsResult([
+        { isResolved: false, authorLogin: "alice", updatedAt: OLD_DATE },
+        { isResolved: false, authorLogin: "alice", updatedAt: OLD_DATE },
+        { isResolved: true, authorLogin: "reviewer", updatedAt: OLD_DATE },
+      ])
+    ) as jest.Mock;
+    const ctx = makeMinimalContext(graphqlFn);
+    expect(await isUserReviewerLagged(ctx, "alice", [PR_ONE], REVIEW_DELAY_TOLERANCE)).toBe(true);
+  });
+
+  it("returns false when user is lagged on one PR but not on another", async () => {
+    const graphqlFn = jest
+      .fn()
+      .mockResolvedValueOnce(buildThreadsResult([{ isResolved: false, authorLogin: "alice", updatedAt: OLD_DATE }]))
+      .mockResolvedValueOnce(buildThreadsResult([{ isResolved: false, authorLogin: "reviewer", updatedAt: OLD_DATE }])) as jest.Mock;
+    const ctx = makeMinimalContext(graphqlFn);
+    expect(await isUserReviewerLagged(ctx, "alice", [PR_ONE, { html_url: "https://github.com/owner/repo/pull/2", number: 2 }], REVIEW_DELAY_TOLERANCE)).toBe(
+      false
+    );
+  });
+
+  it("returns false when graphql throws (fail-safe)", async () => {
+    const graphqlFn = jest.fn().mockRejectedValue(new Error("Network error")) as jest.Mock;
+    const ctx = makeMinimalContext(graphqlFn);
+    expect(await isUserReviewerLagged(ctx, "alice", [PR_ONE], REVIEW_DELAY_TOLERANCE)).toBe(false);
+  });
+
+  it("returns false when PR has no review threads at all", async () => {
+    const graphqlFn = jest.fn().mockResolvedValue(buildThreadsResult([])) as jest.Mock;
+    const ctx = makeMinimalContext(graphqlFn);
+    expect(await isUserReviewerLagged(ctx, "alice", [PR_ONE], REVIEW_DELAY_TOLERANCE)).toBe(false);
+  });
+});
+
+describe("handleTaskLimitChecks: reviewer-lag bypass", () => {
+  beforeEach(async () => {
+    drop(db);
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    jest.resetModules();
+    db.users.create({ id: 1, login: "alice", role: "contributor", created_at: new Date("2020-01-01").toISOString(), xp: 0, wallet: null });
+    db.issue.create({ ...issueTemplate, id: 1 });
+    db.repo.create({ id: 1, html_url: "", name: "test-repo", owner: { login: "ubiquity", id: 1, type: "Organization" }, issues: [] });
+  });
+
+  const OVER_LIMIT_ASSIGNED = [
+    { title: "issue 1", html_url: "https://github.com/owner/repo/issues/10" },
+    { title: "issue 2", html_url: "https://github.com/owner/repo/issues/11" },
+    { title: "issue 3", html_url: "https://github.com/owner/repo/issues/12" },
+  ];
+  const ONE_PENDING_PR = [PR_ONE];
+
+  it("bypasses the task limit and sets isReviewerLagged=true when all pending PRs are reviewer-lagged", async () => {
+    const graphqlFn = jest.fn().mockResolvedValue(buildThreadsResult([{ isResolved: false, authorLogin: "alice", updatedAt: OLD_DATE }]));
+    jest.mock(issueUtilsPath, () => ({
+      getPendingOpenedPullRequests: jest.fn().mockResolvedValue(ONE_PENDING_PR),
+      getAssignedIssues: jest.fn().mockResolvedValue(OVER_LIMIT_ASSIGNED),
+      getOwnerRepoFromHtmlUrl: (url: string) => {
+        const p = url.split("/");
+        return { owner: p[3], repo: p[4] };
+      },
+      getTimeValue: () => 259200000,
+    }));
+    jest.mock(userLimitUtilsPath, () => ({ getUserRoleAndTaskLimit: jest.fn().mockResolvedValue({ role: "contributor", limit: 2 }) }));
+    jest.mock(assignmentPeriodsPath, () => ({ getAssignmentPeriods: jest.fn().mockResolvedValue({}) }));
+
+    const issue = db.issue.findFirst({ where: { id: { equals: 1 } } }) as unknown as Issue;
+    const sender = db.users.findFirst({ where: { id: { equals: 1 } } }) as unknown as PayloadSender;
+    const context = (await createContext(issue, sender, "/start")) as Context & { installOctokit: Context["octokit"] };
+    const patchedOctokit = Object.create(context.octokit) as typeof context.octokit;
+    (patchedOctokit as { graphql: jest.Mock }).graphql = graphqlFn;
+    context.octokit = patchedOctokit;
+
+    const { handleTaskLimitChecks: fn } = await import(checkAssignmentsPath);
+    const result = await fn({ context, logger: context.logger, sender: "alice", username: "alice" });
+
+    expect(result.isWithinLimit).toBe(true);
+    expect(result.isReviewerLagged).toBe(true);
+    expect(result.isUnassigned).toBe(false);
+  });
+
+  it("enforces the task limit when the reviewer — not the user — last commented", async () => {
+    const graphqlFn = jest.fn().mockResolvedValue(buildThreadsResult([{ isResolved: false, authorLogin: "reviewer", updatedAt: OLD_DATE }]));
+    jest.mock(issueUtilsPath, () => ({
+      getPendingOpenedPullRequests: jest.fn().mockResolvedValue(ONE_PENDING_PR),
+      getAssignedIssues: jest.fn().mockResolvedValue(OVER_LIMIT_ASSIGNED),
+      getOwnerRepoFromHtmlUrl: (url: string) => {
+        const p = url.split("/");
+        return { owner: p[3], repo: p[4] };
+      },
+      getTimeValue: () => 259200000,
+    }));
+    jest.mock(userLimitUtilsPath, () => ({ getUserRoleAndTaskLimit: jest.fn().mockResolvedValue({ role: "contributor", limit: 2 }) }));
+    jest.mock(assignmentPeriodsPath, () => ({ getAssignmentPeriods: jest.fn().mockResolvedValue({}) }));
+
+    const issue = db.issue.findFirst({ where: { id: { equals: 1 } } }) as unknown as Issue;
+    const sender = db.users.findFirst({ where: { id: { equals: 1 } } }) as unknown as PayloadSender;
+    const context = (await createContext(issue, sender, "/start")) as Context & { installOctokit: Context["octokit"] };
+    const patchedOctokit = Object.create(context.octokit) as typeof context.octokit;
+    (patchedOctokit as { graphql: jest.Mock }).graphql = graphqlFn;
+    context.octokit = patchedOctokit;
+
+    const { handleTaskLimitChecks: fn } = await import(checkAssignmentsPath);
+    const result = await fn({ context, logger: context.logger, sender: "alice", username: "alice" });
+
+    expect(result.isWithinLimit).toBe(false);
+    expect(result.isReviewerLagged).toBe(false);
+  });
+
+  it("enforces the task limit when there are no pending PRs to check", async () => {
+    jest.mock(issueUtilsPath, () => ({
+      getPendingOpenedPullRequests: jest.fn().mockResolvedValue([]),
+      getAssignedIssues: jest.fn().mockResolvedValue(OVER_LIMIT_ASSIGNED),
+      getOwnerRepoFromHtmlUrl: (url: string) => {
+        const p = url.split("/");
+        return { owner: p[3], repo: p[4] };
+      },
+      getTimeValue: () => 259200000,
+    }));
+    jest.mock(userLimitUtilsPath, () => ({ getUserRoleAndTaskLimit: jest.fn().mockResolvedValue({ role: "contributor", limit: 2 }) }));
+    jest.mock(assignmentPeriodsPath, () => ({ getAssignmentPeriods: jest.fn().mockResolvedValue({}) }));
+
+    const issue = db.issue.findFirst({ where: { id: { equals: 1 } } }) as unknown as Issue;
+    const sender = db.users.findFirst({ where: { id: { equals: 1 } } }) as unknown as PayloadSender;
+    const context = (await createContext(issue, sender, "/start")) as Context & { installOctokit: Context["octokit"] };
+
+    const { handleTaskLimitChecks: fn } = await import(checkAssignmentsPath);
+    const result = await fn({ context, logger: context.logger, sender: "alice", username: "alice" });
+
+    // abs(3 - 0) = 3 >= 2 → over limit; no PRs to check → no bypass
+    expect(result.isWithinLimit).toBe(false);
+    expect(result.isReviewerLagged).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `isUserReviewerLagged()` that checks whether **all** of a user's pending open PRs have unresolved review threads where the user commented last and the `reviewDelayTolerance` window has already elapsed
- Modifies `handleTaskLimitChecks` to call this check whenever a user would otherwise be blocked by the task limit; if reviewer-lagged, `isWithinLimit` is returned as `true` and `isReviewerLagged: true` is included
- Adds `QUERY_PULL_REQUEST_REVIEW_THREADS` GraphQL query to `github-queries.ts`
- Updates `jest.config.ts` transform to cover `.mjs` files (required for msw >= 2.14)

## How it works

When the task limit is exceeded, `isUserReviewerLagged` iterates every pending PR and fetches its review threads via GraphQL. A PR is reviewer-lagged when every unresolved thread has the user as the last commenter and that comment is older than `reviewDelayTolerance`. Only if ALL pending PRs satisfy this is the limit bypassed.

## Test plan

- [x] 8 unit tests for `isUserReviewerLagged` covering all branches
- [x] 3 integration-style tests for `handleTaskLimitChecks` bypass, enforcement, and no-PR edge case

Closes #106

https://claude.ai/code/session_01VbqDyLGYRh6bpyhga6AgEo