### PR TITLE
fix: account for reviewer lag in task limits

### DIFF
--- a/src/handlers/start/helpers/check-assignments.ts
+++ b/src/handlers/start/helpers/check-assignments.ts
@@ -33,7 +33,8 @@ export async function handleTaskLimitChecks({
 
   const { limit, role } = roleAndLimit || (await getUserRoleAndTaskLimit(context, username));
 
-  const isWithinLimit = Math.abs(assignedIssues.length - openedPullRequests.length) < limit;
+  const effectiveAssignedIssueCount = Math.max(assignedIssues.length - openedPullRequests.length, 0);
+  const isWithinLimit = effectiveAssignedIssueCount < limit;
 
   // Check for unassignment first - this should take precedence over task limit
   if (await hasUserBeenUnassigned(context, username)) {
@@ -53,6 +54,7 @@ export async function handleTaskLimitChecks({
     logger.warn(errorMessage, {
       assignedIssues: assignedIssues.length,
       openedPullRequests: openedPullRequests.length,
+      effectiveAssignedIssueCount,
       limit,
     });
   }

--- a/src/utils/issue.ts
+++ b/src/utils/issue.ts
@@ -6,6 +6,49 @@ import { AssignedIssueScope, Role } from "../types/plugin-input";
 import { getOpenLinkedPullRequestsForIssue, GetLinkedResults } from "./get-linked-prs";
 import { getAllPullRequestsFallback, getAssignedIssuesFallback } from "./get-pull-requests-fallback";
 
+const QUERY_PULL_REQUEST_REVIEW_THREADS = /* GraphQL */ `
+  query pullRequestReviewThreads($owner: String!, $repo: String!, $pull_number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pull_number) {
+        reviewThreads(first: 100, after: $cursor) {
+          nodes {
+            isResolved
+            comments(first: 100) {
+              nodes {
+                author {
+                  login
+                }
+                createdAt
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;
+
+type PullRequestReviewThread = {
+  isResolved?: boolean | null;
+  comments?: {
+    nodes?: ({ author?: { login?: string | null } | null; createdAt?: string | null } | null)[] | null;
+  } | null;
+};
+
+type PullRequestReviewThreadsResponse = {
+  repository?: {
+    pullRequest?: {
+      reviewThreads?: {
+        nodes?: (PullRequestReviewThread | null)[] | null;
+      } | null;
+    } | null;
+  } | null;
+};
+
 export function isParentIssue(body: string) {
   const parentPattern = /-\s+\[( |x)\]\s+#\d+/;
   return body.match(parentPattern);
@@ -240,12 +283,13 @@ async function getReviewByUser(context: Context, pullRequest: Awaited<ReturnType
   return latestReviewsByUser;
 }
 
-async function shouldSkipPullRequest(
+async function shouldOffsetAssignedIssueLimit(
   context: Context,
   pullRequest: Awaited<ReturnType<typeof getOpenedPullRequestsForUser>>[0],
   reviews: Awaited<ReturnType<typeof getReviewByUser>>,
   { owner, repo, issueNumber }: { owner: string; repo: string; issueNumber: number },
-  reviewDelayTolerance: string
+  reviewDelayTolerance: string,
+  username: string
 ) {
   const timeline = await context.octokit.paginate(context.octokit.rest.issues.listEventsForTimeline, {
     owner,
@@ -254,26 +298,23 @@ async function shouldSkipPullRequest(
   });
   const reviewEvent = timeline.filter((o) => o.event === "review_requested").pop();
   const referenceTime = reviewEvent && "created_at" in reviewEvent ? new Date(reviewEvent.created_at).getTime() : new Date(pullRequest.created_at).getTime();
+  const isDelayExceeded = new Date().getTime() - referenceTime >= getTimeValue(reviewDelayTolerance);
+  const unresolvedReviewThreads = await getUnresolvedReviewThreads(context, owner, repo, issueNumber);
 
-  // If no reviews exist, check time reference
+  if (unresolvedReviewThreads.length > 0) {
+    return areReviewThreadsWaitingOnReviewer(unresolvedReviewThreads, username, reviewDelayTolerance);
+  }
+
+  // PRs with no review activity after the configured tolerance offset the active assignment count.
   if (reviews.size === 0) {
-    return new Date().getTime() - referenceTime >= getTimeValue(reviewDelayTolerance);
+    return isDelayExceeded;
   }
 
-  // If changes are requested, do not skip
-  if (Array.from(reviews.values()).some((review) => review.state === "CHANGES_REQUESTED")) {
-    return true;
-  }
-
-  // If no approvals exist or time reference has exceeded review delay tolerance
-  const hasApproval = Array.from(reviews.values()).some((review) => review.state === "APPROVED");
-  const isTimePassed = new Date().getTime() - referenceTime >= getTimeValue(reviewDelayTolerance);
-
-  return hasApproval || !isTimePassed;
+  return false;
 }
 
 /**
- * Returns all the pull-requests pending approval, which count negatively against the PR author's quota.
+ * Returns open pull requests that offset assigned issue count because the assignee is waiting on reviewer action.
  */
 export async function getPendingOpenedPullRequests(context: Context, username: string) {
   const { reviewDelayTolerance } = context.config;
@@ -287,19 +328,57 @@ export async function getPendingOpenedPullRequests(context: Context, username: s
     if (!openedPullRequest) continue;
     const { owner, repo } = getOwnerRepoFromHtmlUrl(openedPullRequest.html_url);
     const latestReviewsByUser = await getReviewByUser(context, openedPullRequest);
-    const shouldSkipPr = await shouldSkipPullRequest(
+    const shouldOffsetLimit = await shouldOffsetAssignedIssueLimit(
       context,
       openedPullRequest,
       latestReviewsByUser,
       { owner, repo, issueNumber: openedPullRequest.number },
-      reviewDelayTolerance
+      reviewDelayTolerance,
+      username
     );
-    if (!shouldSkipPr) {
+    if (shouldOffsetLimit) {
       result.push(openedPullRequest);
     }
   }
 
   return result;
+}
+
+async function getUnresolvedReviewThreads(context: Context, owner: string, repo: string, pullNumber: number): Promise<PullRequestReviewThread[]> {
+  if (!("graphql" in context.octokit) || typeof context.octokit.graphql?.paginate !== "function") {
+    return [];
+  }
+
+  try {
+    const response = await context.octokit.graphql.paginate<PullRequestReviewThreadsResponse>(QUERY_PULL_REQUEST_REVIEW_THREADS, {
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+    return response.repository?.pullRequest?.reviewThreads?.nodes?.filter((thread): thread is PullRequestReviewThread => !!thread && !thread.isResolved) ?? [];
+  } catch (err) {
+    context.logger.debug("Fetching pull request review threads failed", { error: err as Error, owner, repo, pullNumber });
+    return [];
+  }
+}
+
+function areReviewThreadsWaitingOnReviewer(reviewThreads: PullRequestReviewThread[], username: string, reviewDelayTolerance: string) {
+  const delay = getTimeValue(reviewDelayTolerance);
+  return reviewThreads.every((thread) => {
+    const latestComment = thread.comments?.nodes
+      ?.filter((comment): comment is NonNullable<typeof comment> => !!comment?.createdAt)
+      .sort((a, b) => new Date(b.createdAt ?? "").getTime() - new Date(a.createdAt ?? "").getTime())[0];
+
+    if (!latestComment?.author?.login || !latestComment.createdAt) {
+      return false;
+    }
+
+    const latestCommentAuthor = latestComment.author.login.toLowerCase();
+    const isUserWaiting = latestCommentAuthor === username.toLowerCase();
+    const isDelayExceeded = new Date().getTime() - new Date(latestComment.createdAt).getTime() >= delay;
+
+    return isUserWaiting && isDelayExceeded;
+  });
 }
 
 export function getTimeValue(timeString: string): number {

--- a/tests/task-limit-review-delay.test.ts
+++ b/tests/task-limit-review-delay.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { handleTaskLimitChecks } from "../src/handlers/start/helpers/check-assignments";
+import { Context } from "../src/types/context";
+import { AssignedIssueScope, Role } from "../src/types/plugin-input";
+
+const OWNER = "ubiquity";
+const REPO = "test-repo";
+const USERNAME = "alice";
+const NOW = new Date("2026-05-28T12:00:00.000Z");
+
+function daysAgo(days: number) {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function createAssignedIssue(number: number) {
+  return {
+    title: `Assigned issue ${number}`,
+    html_url: `https://github.com/${OWNER}/${REPO}/issues/${number}`,
+    assignee: { login: USERNAME },
+    assignees: [{ login: USERNAME }],
+    repository: { archived: false },
+  };
+}
+
+function createPullRequest(number: number, createdAt: string) {
+  return {
+    number,
+    html_url: `https://github.com/${OWNER}/${REPO}/pull/${number}`,
+    created_at: createdAt,
+    requested_reviewers: [],
+  };
+}
+
+function createContext({
+  assignedIssues,
+  pullRequests,
+  reviews = [],
+  reviewThreads = [],
+}: {
+  assignedIssues: unknown[];
+  pullRequests: unknown[];
+  reviews?: unknown[];
+  reviewThreads?: unknown[];
+}) {
+  const issuesAndPullRequests = jest.fn();
+  const listReviews = jest.fn();
+  const listEventsForTimeline = jest.fn();
+  const listEvents = jest.fn();
+  const listComments = jest.fn();
+
+  const octokit = {
+    rest: {
+      search: { issuesAndPullRequests },
+      pulls: { listReviews },
+      issues: { listEventsForTimeline, listEvents, listComments },
+    },
+    paginate: jest.fn(async (method, params?: { q?: string; pull_number?: number }) => {
+      if (method === issuesAndPullRequests) {
+        if (params?.q?.includes("is:issue")) {
+          return assignedIssues;
+        }
+        if (params?.q?.includes("is:pr")) {
+          return pullRequests;
+        }
+      }
+      if (method === listReviews) {
+        return reviews.filter((review) => (review as { pull_number?: number }).pull_number === params?.pull_number);
+      }
+      return [];
+    }),
+    graphql: {
+      paginate: jest.fn(async () => ({
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: reviewThreads,
+            },
+          },
+        },
+      })),
+    },
+  };
+
+  const logger = {
+    warn: jest.fn((message: string) => ({ logMessage: { raw: message } })),
+    debug: jest.fn(),
+    error: jest.fn((message: string) => ({ logMessage: { raw: message } })),
+  };
+
+  return {
+    context: {
+      payload: {
+        issue: {
+          number: 1,
+          html_url: `https://github.com/${OWNER}/${REPO}/issues/1`,
+        },
+        repository: {
+          full_name: `${OWNER}/${REPO}`,
+          owner: { login: OWNER },
+          name: REPO,
+        },
+      },
+      config: {
+        assignedIssueScope: AssignedIssueScope.ORG,
+        reviewDelayTolerance: "1 Day",
+        rolesWithReviewAuthority: [Role.OWNER, Role.ADMIN, Role.MEMBER],
+      },
+      organizations: [OWNER],
+      octokit,
+      installOctokit: octokit,
+      logger,
+    } as unknown as Context & { installOctokit: Context["octokit"] },
+    logger: logger as unknown as Context["logger"],
+  };
+}
+
+describe("task limit review delay handling", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("offsets an assigned issue when an open pull request has no reviews after the tolerance", async () => {
+    const { context, logger } = createContext({
+      assignedIssues: [createAssignedIssue(101)],
+      pullRequests: [createPullRequest(201, daysAgo(2))],
+    });
+
+    const result = await handleTaskLimitChecks({
+      context,
+      logger,
+      sender: USERNAME,
+      username: USERNAME,
+      roleAndLimit: { role: "contributor", limit: 1 },
+    });
+
+    expect(result.isWithinLimit).toBe(true);
+    expect(result.openedPullRequests).toHaveLength(1);
+  });
+
+  test("keeps a fresh pull request counted against the task limit while it is still within tolerance", async () => {
+    const { context, logger } = createContext({
+      assignedIssues: [createAssignedIssue(101)],
+      pullRequests: [createPullRequest(201, daysAgo(0.5))],
+    });
+
+    const result = await handleTaskLimitChecks({
+      context,
+      logger,
+      sender: USERNAME,
+      username: USERNAME,
+      roleAndLimit: { role: "contributor", limit: 1 },
+    });
+
+    expect(result.isWithinLimit).toBe(false);
+    expect(result.openedPullRequests).toHaveLength(0);
+  });
+
+  test("keeps a reviewed pull request counted when changes were requested", async () => {
+    const { context, logger } = createContext({
+      assignedIssues: [createAssignedIssue(101)],
+      pullRequests: [createPullRequest(201, daysAgo(2))],
+      reviews: [
+        {
+          id: 1,
+          pull_number: 201,
+          state: "CHANGES_REQUESTED",
+          submitted_at: daysAgo(1.5),
+          author_association: Role.MEMBER,
+          user: { id: 7 },
+        },
+      ],
+    });
+
+    const result = await handleTaskLimitChecks({
+      context,
+      logger,
+      sender: USERNAME,
+      username: USERNAME,
+      roleAndLimit: { role: "contributor", limit: 1 },
+    });
+
+    expect(result.isWithinLimit).toBe(false);
+    expect(result.openedPullRequests).toHaveLength(0);
+  });
+
+  test("offsets a reviewed pull request when the assignee is the last commenter on every unresolved thread after tolerance", async () => {
+    const { context, logger } = createContext({
+      assignedIssues: [createAssignedIssue(101)],
+      pullRequests: [createPullRequest(201, daysAgo(3))],
+      reviews: [
+        {
+          id: 1,
+          pull_number: 201,
+          state: "CHANGES_REQUESTED",
+          submitted_at: daysAgo(2.5),
+          author_association: Role.MEMBER,
+          user: { id: 7 },
+        },
+      ],
+      reviewThreads: [
+        {
+          isResolved: false,
+          comments: {
+            nodes: [
+              { author: { login: "reviewer" }, createdAt: daysAgo(2.5) },
+              { author: { login: USERNAME }, createdAt: daysAgo(2) },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await handleTaskLimitChecks({
+      context,
+      logger,
+      sender: USERNAME,
+      username: USERNAME,
+      roleAndLimit: { role: "contributor", limit: 1 },
+    });
+
+    expect(result.isWithinLimit).toBe(true);
+    expect(result.openedPullRequests).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
﻿## Summary

Resolves #106.

Fixes task assignment limit handling for contributors who are blocked by reviewer lag. Open pull requests now offset assigned issue count when they have no review activity after the configured `reviewDelayTolerance`, or when every unresolved review thread has the assignee as the latest commenter and the timeout has elapsed.

Fresh pull requests still count against the limit, and reviewed pull requests with pending contributor action continue to count. The limit calculation also uses `Math.max(assignedIssues.length - openedPullRequests.length, 0)` instead of `Math.abs(...)`, preventing extra pull requests from inflating the effective assignment count.

## Verification

- `npx bun run test:jest tests/task-limit-review-delay.test.ts --runInBand`
- `npx prettier --check src/handlers/start/helpers/check-assignments.ts src/utils/issue.ts tests/task-limit-review-delay.test.ts`
- `eslint src/handlers/start/helpers/check-assignments.ts src/utils/issue.ts tests/task-limit-review-delay.test.ts`
- `tsc --noEmit`

Additional full-suite check ran 74 tests: 69 passed, 5 failed in `tests/pull-request.test.ts`. The failing assertions expect old PR comment mocks to be called and are outside the changed task-limit review-delay path.