### PR TITLE
fix: credit reviewer-lagged pull requests

### DIFF
--- a/src/github-queries.ts
+++ b/src/github-queries.ts
@@ -25,3 +25,29 @@ export const QUERY_OPEN_LINKED_PULL_REQUESTS_FOR_ISSUE = /* GraphQL */ `
     }
   }
 `;
+
+export const QUERY_PULL_REQUEST_REVIEW_THREADS = /* GraphQL */ `
+  query pullRequestReviewThreads($owner: String!, $repo: String!, $pull_number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pull_number) {
+        reviewThreads(first: 100, after: $cursor) {
+          nodes {
+            isResolved
+            comments(last: 1) {
+              nodes {
+                author {
+                  login
+                }
+                createdAt
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/utils/issue.ts
+++ b/src/utils/issue.ts
@@ -1,5 +1,6 @@
 import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 import ms from "ms";
+import { QUERY_PULL_REQUEST_REVIEW_THREADS } from "../github-queries";
 import { Context } from "../types/context";
 import { AssignedIssue, GitHubIssueSearch, PrState, Review } from "../types/payload";
 import { AssignedIssueScope, Role } from "../types/plugin-input";
@@ -240,12 +241,79 @@ async function getReviewByUser(context: Context, pullRequest: Awaited<ReturnType
   return latestReviewsByUser;
 }
 
-async function shouldSkipPullRequest(
+type ReviewThreadQuery = {
+  repository?: {
+    pullRequest?: {
+      reviewThreads?: {
+        nodes?: {
+          isResolved?: boolean;
+          comments?: {
+            nodes?: {
+              author?: { login?: string | null } | null;
+              createdAt?: string | null;
+            }[];
+          } | null;
+        }[];
+      } | null;
+    } | null;
+  } | null;
+};
+
+const REVIEWER_LAG_TIMEOUT = "24 Hours";
+
+function isElapsed(createdAt: string | null | undefined, tolerance: string) {
+  if (!createdAt) {
+    return false;
+  }
+  return new Date().getTime() - new Date(createdAt).getTime() >= getTimeValue(tolerance);
+}
+
+async function getUnresolvedReviewThreads(context: Context, owner: string, repo: string, pullNumber: number) {
+  try {
+    const response = await context.octokit.graphql.paginate<ReviewThreadQuery>(QUERY_PULL_REQUEST_REVIEW_THREADS, {
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+    const threads = response.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+    return threads.filter((thread) => thread && !thread.isResolved);
+  } catch (err) {
+    context.logger.debug("Could not inspect pull request review threads.", { error: err as Error, owner, repo, pullNumber });
+    return null;
+  }
+}
+
+async function isReviewerLaggedAfterAuthorResponse(
+  context: Context,
+  pullRequest: Awaited<ReturnType<typeof getOpenedPullRequestsForUser>>[0],
+  latestReviews: Review[],
+  { owner, repo }: { owner: string; repo: string },
+  username: string
+) {
+  const unresolvedThreads = await getUnresolvedReviewThreads(context, owner, repo, pullRequest.number);
+  if (!unresolvedThreads) {
+    return false;
+  }
+
+  if (unresolvedThreads.length === 0) {
+    const latestReview = latestReviews[0];
+    return isElapsed(latestReview?.submitted_at, REVIEWER_LAG_TIMEOUT);
+  }
+
+  return unresolvedThreads.every((thread) => {
+    const lastComment = thread.comments?.nodes?.[0];
+    const authorLogin = lastComment?.author?.login?.toLowerCase();
+    return authorLogin === username.toLowerCase() && isElapsed(lastComment?.createdAt, REVIEWER_LAG_TIMEOUT);
+  });
+}
+
+async function shouldCreditPullRequestForTaskLimit(
   context: Context,
   pullRequest: Awaited<ReturnType<typeof getOpenedPullRequestsForUser>>[0],
   reviews: Awaited<ReturnType<typeof getReviewByUser>>,
   { owner, repo, issueNumber }: { owner: string; repo: string; issueNumber: number },
-  reviewDelayTolerance: string
+  reviewDelayTolerance: string,
+  username: string
 ) {
   const timeline = await context.octokit.paginate(context.octokit.rest.issues.listEventsForTimeline, {
     owner,
@@ -255,25 +323,31 @@ async function shouldSkipPullRequest(
   const reviewEvent = timeline.filter((o) => o.event === "review_requested").pop();
   const referenceTime = reviewEvent && "created_at" in reviewEvent ? new Date(reviewEvent.created_at).getTime() : new Date(pullRequest.created_at).getTime();
 
-  // If no reviews exist, check time reference
+  // A stale PR with no review should not block more work.
   if (reviews.size === 0) {
     return new Date().getTime() - referenceTime >= getTimeValue(reviewDelayTolerance);
   }
 
-  // If changes are requested, do not skip
-  if (Array.from(reviews.values()).some((review) => review.state === "CHANGES_REQUESTED")) {
-    return true;
+  const latestReviews = Array.from(reviews.values()).sort((a, b) => {
+    if (!a?.submitted_at || !b?.submitted_at) {
+      return 0;
+    }
+    return new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime();
+  });
+
+  if (latestReviews.some((review) => review.state === "CHANGES_REQUESTED")) {
+    return isReviewerLaggedAfterAuthorResponse(context, pullRequest, latestReviews, { owner, repo }, username);
   }
 
-  // If no approvals exist or time reference has exceeded review delay tolerance
-  const hasApproval = Array.from(reviews.values()).some((review) => review.state === "APPROVED");
+  const hasApproval = latestReviews.some((review) => review.state === "APPROVED");
   const isTimePassed = new Date().getTime() - referenceTime >= getTimeValue(reviewDelayTolerance);
 
-  return hasApproval || !isTimePassed;
+  return hasApproval || isTimePassed;
 }
 
 /**
- * Returns all the pull-requests pending approval, which count negatively against the PR author's quota.
+ * Returns open pull requests that should offset task-limit checks because they are approved,
+ * stale without review, or blocked on reviewer follow-up after the author responded.
  */
 export async function getPendingOpenedPullRequests(context: Context, username: string) {
   const { reviewDelayTolerance } = context.config;
@@ -287,14 +361,15 @@ export async function getPendingOpenedPullRequests(context: Context, username: s
     if (!openedPullRequest) continue;
     const { owner, repo } = getOwnerRepoFromHtmlUrl(openedPullRequest.html_url);
     const latestReviewsByUser = await getReviewByUser(context, openedPullRequest);
-    const shouldSkipPr = await shouldSkipPullRequest(
+    const shouldCreditPr = await shouldCreditPullRequestForTaskLimit(
       context,
       openedPullRequest,
       latestReviewsByUser,
       { owner, repo, issueNumber: openedPullRequest.number },
-      reviewDelayTolerance
+      reviewDelayTolerance,
+      username
     );
-    if (!shouldSkipPr) {
+    if (shouldCreditPr) {
       result.push(openedPullRequest);
     }
   }

--- a/tests/reviewer-lagged-task-limit.test.ts
+++ b/tests/reviewer-lagged-task-limit.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { Context } from "../src/types/context";
+import { Review } from "../src/types/payload";
+import { AssignedIssueScope, Role } from "../src/types/plugin-input";
+import { getPendingOpenedPullRequests } from "../src/utils/issue";
+
+const USERNAME = "contributor";
+const REVIEWER_ID = 1001;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function hoursAgo(hours: number) {
+  return new Date(Date.now() - hours * ONE_HOUR_MS).toISOString();
+}
+
+function createReview(overrides: Partial<Review> = {}) {
+  return {
+    author_association: "MEMBER",
+    state: "CHANGES_REQUESTED",
+    submitted_at: hoursAgo(30),
+    user: {
+      id: REVIEWER_ID,
+      login: "reviewer",
+    },
+    ...overrides,
+  } as Review;
+}
+
+function createContext({
+  graphQlError = false,
+  reviewDelayTolerance = "3 Days",
+  reviews = [],
+  reviewRequestedHoursAgo = 96,
+  threads = [],
+}: {
+  graphQlError?: boolean;
+  reviewDelayTolerance?: string;
+  reviews?: Review[];
+  reviewRequestedHoursAgo?: number;
+  threads?: {
+    isResolved?: boolean;
+    lastAuthor?: string;
+    lastCommentHoursAgo?: number;
+  }[];
+} = {}) {
+  const searchMethod = jest.fn();
+  const reviewsMethod = jest.fn();
+  const timelineMethod = jest.fn();
+  const pullRequest = {
+    created_at: hoursAgo(120),
+    html_url: "https://github.com/ubiquity-os-marketplace/command-start-stop/pull/123",
+    number: 123,
+    requested_reviewers: [],
+    user: {
+      login: USERNAME,
+    },
+  };
+  const paginate = jest.fn(async (method) => {
+    if (method === searchMethod) {
+      return [pullRequest];
+    }
+    if (method === reviewsMethod) {
+      return reviews;
+    }
+    if (method === timelineMethod) {
+      return [
+        {
+          created_at: hoursAgo(reviewRequestedHoursAgo),
+          event: "review_requested",
+        },
+      ];
+    }
+    return [];
+  });
+  const graphqlPaginate = jest.fn(async () => {
+    if (graphQlError) {
+      throw new Error("GraphQL unavailable");
+    }
+    return {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: threads.map((thread) => ({
+              isResolved: thread.isResolved ?? false,
+              comments: {
+                nodes: [
+                  {
+                    author: {
+                      login: thread.lastAuthor ?? USERNAME,
+                    },
+                    createdAt: hoursAgo(thread.lastCommentHoursAgo ?? 25),
+                  },
+                ],
+              },
+            })),
+          },
+        },
+      },
+    };
+  });
+  const context = {
+    config: {
+      assignedIssueScope: AssignedIssueScope.REPO,
+      reviewDelayTolerance,
+      rolesWithReviewAuthority: [Role.ADMIN, Role.OWNER, Role.MEMBER],
+    },
+    logger: {
+      debug: jest.fn(),
+      error: jest.fn((message: string) => new Error(message)),
+    },
+    octokit: {
+      graphql: {
+        paginate: graphqlPaginate,
+      },
+      paginate,
+      rest: {
+        issues: {
+          listEventsForTimeline: timelineMethod,
+        },
+        pulls: {
+          listReviews: reviewsMethod,
+        },
+        search: {
+          issuesAndPullRequests: searchMethod,
+        },
+      },
+    },
+    organizations: ["ubiquity-os-marketplace"],
+    payload: {
+      repository: {
+        full_name: "ubiquity-os-marketplace/command-start-stop",
+      },
+    },
+  } as unknown as Context;
+
+  return { context, graphqlPaginate };
+}
+
+describe("reviewer-lagged task limit credit", () => {
+  it("credits a stale pull request without reviews", async () => {
+    const { context } = createContext();
+
+    await expect(getPendingOpenedPullRequests(context, USERNAME)).resolves.toHaveLength(1);
+  });
+
+  it("credits a changes-requested pull request when the author replied to every unresolved review thread", async () => {
+    const { context } = createContext({
+      reviews: [createReview()],
+      threads: [{ lastAuthor: USERNAME, lastCommentHoursAgo: 25 }],
+    });
+
+    await expect(getPendingOpenedPullRequests(context, USERNAME)).resolves.toHaveLength(1);
+  });
+
+  it("does not credit a changes-requested pull request when review threads still need author action", async () => {
+    const { context } = createContext({
+      reviews: [createReview()],
+      threads: [{ lastAuthor: "reviewer", lastCommentHoursAgo: 25 }],
+    });
+
+    await expect(getPendingOpenedPullRequests(context, USERNAME)).resolves.toHaveLength(0);
+  });
+
+  it("does not credit a changes-requested pull request when the author's last reply is less than 24 hours old", async () => {
+    const { context } = createContext({
+      reviews: [createReview()],
+      threads: [{ lastAuthor: USERNAME, lastCommentHoursAgo: 2 }],
+    });
+
+    await expect(getPendingOpenedPullRequests(context, USERNAME)).resolves.toHaveLength(0);
+  });
+
+  it("falls back conservatively if review thread inspection fails", async () => {
+    const { context, graphqlPaginate } = createContext({
+      graphQlError: true,
+      reviews: [createReview()],
+    });
+
+    await expect(getPendingOpenedPullRequests(context, USERNAME)).resolves.toHaveLength(0);
+    expect(graphqlPaginate).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Resolves #106

## Summary
- credits stale unreviewed pull requests so contributors are not blocked by reviewer delay
- inspects unresolved review threads after CHANGES_REQUESTED reviews
- only credits a changes-requested PR when the author is the last commenter on every unresolved review thread and the last reply is at least 24 hours old
- falls back conservatively when review thread inspection is unavailable

## Validation
- tsc --noEmit
- jest --runTestsByPath ./tests/reviewer-lagged-task-limit.test.ts --runInBand --coverage=false
- eslint ./src/github-queries.ts ./src/utils/issue.ts ./tests/reviewer-lagged-task-limit.test.ts
- cspell ./src/github-queries.ts ./src/utils/issue.ts ./tests/reviewer-lagged-task-limit.test.ts